### PR TITLE
Update vinyl-buffer version

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"babel-preset-es2015": "^6.16.0",
 		"browserify": "^13.1.1",
 		"vinyl-source-stream": "^1.1.0",
-		"vinyl-buffer": "^1.1.0"
+		"vinyl-buffer": "^1.0.0"
 	},
 	"babel": {
 		"presets": ["es2015"]


### PR DESCRIPTION
Update to 1.0.0 - the latest version on https://www.npmjs.com/package/vinyl-buffer