### PR TITLE
Laravel-Mix Bug Fix for Windows Environment

### DIFF
--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -30,6 +30,8 @@ mix.autoload({
     'jquery': ['jQuery', '$']
 });
 
+mix.setPublicPath('./');
+
 // Compile assets
 mix.js( 'assets/src/scripts/app.js', 'assets/dist/js' )
 	.js( 'assets/src/scripts/admin.js', 'assets/dist/js' )


### PR DESCRIPTION
In my Windows Environment the compiling process of laravel-mix has stopped after "emitting 95%". Other people have had similar issues as it can be seen [here](https://github.com/JeffreyWay/laravel-mix/issues/1126) on the GitHub of laravel-mix.

This extra line fixes it for now.