### PR TITLE
Added Laravel Mix Versioning for Production

### DIFF
--- a/assets/dist/mix-manifest.json
+++ b/assets/dist/mix-manifest.json
@@ -1,0 +1,8 @@
+{
+    "/js/app.js": "/js/app.js",
+    "/css/style.css": "/css/style.css",
+    "/css/admin.css": "/css/admin.css",
+    "/css/gutenberg.css": "/css/gutenberg.css",
+    "/js/gutenberg.js": "/js/gutenberg.js",
+    "/js/admin.js": "/js/admin.js"
+}

--- a/inc/Helpers.php
+++ b/inc/Helpers.php
@@ -21,3 +21,60 @@ if ( ! function_exists( 'dd' ) ) :
 		die;
 	}
 endif;
+
+if (! function_exists('starts_with')) {
+    /**
+     * Determine if a given string starts with a given substring.
+     *
+     * @param  string  $haystack
+     * @param  string|array  $needles
+     * @return bool
+     */
+    function starts_with($haystack, $needles)
+    {
+        foreach ((array) $needles as $needle) {
+            if ($needle != '' && substr($haystack, 0, strlen($needle)) === (string) $needle) {
+                return true;
+            }
+        }
+        return false;
+    }
+}
+if (! function_exists('mix')) {
+    /**
+     * Get the path to a versioned Mix file.
+     *
+     * @param  string  $path
+     * @param  string  $manifestDirectory
+     * @return \Illuminate\Support\HtmlString
+     *
+     * @throws \Exception
+     */
+    function mix($path, $manifestDirectory = '')
+    {
+		if ( !$manifestDirectory) {
+			//Setup path for standard AWPS-Folder-Structure
+			$manifestDirectory = "assets/dist/";
+		}
+        static $manifest;
+        if (! starts_with($path, '/')) {
+            $path = "/{$path}";
+		}
+        if ($manifestDirectory && ! starts_with($manifestDirectory, '/')) {
+            $manifestDirectory = "/{$manifestDirectory}";
+		}
+		$rootDir = dirname(__FILE__, 2);
+        if (file_exists($rootDir . '/' . $manifestDirectory.'/hot')) {
+            return "http://localhost:8080" . $path;
+        }
+        if (! $manifest) {
+			$manifestPath =  $rootDir . $manifestDirectory . 'mix-manifest.json';
+            if (! file_exists($manifestPath)) {
+                throw new Exception('The Mix manifest does not exist.');
+            }
+			$manifest = json_decode(file_get_contents($manifestPath), true);
+		}
+		$path = $manifestDirectory . $manifest[$path];
+		return get_template_directory_uri() . $path;
+    }
+}

--- a/inc/Setup/Enqueue.php
+++ b/inc/Setup/Enqueue.php
@@ -16,6 +16,12 @@ class Enqueue
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 	}
 
+	/**
+	 * Notice the mix() function in wp_enqueue_...
+	 * It provides the path to a versioned asset by Laravel Mix using querystring-based 
+	 * cache-busting (This means, the file name won't change, but the md5. Look here for 
+	 * more information: https://github.com/JeffreyWay/laravel-mix/issues/920 )
+	 */
 	public function enqueue_scripts() 
 	{
 		// Deregister the built-in version of jQuery from WordPress
@@ -24,10 +30,10 @@ class Enqueue
 		}
 
 		// CSS
-		wp_enqueue_style( 'main', get_template_directory_uri() . '/assets/dist/css/style.css', array(), '1.0.0', 'all' );
+		wp_enqueue_style( 'main', mix('css/style.css'), array(), '1.0.0', 'all' );
 
 		// JS
-		wp_enqueue_script( 'main', get_template_directory_uri() . '/assets/dist/js/app.js', array(), '1.0.0', true );
+		wp_enqueue_script( 'main', mix('js/app.js'), array(), '1.0.0', true );
 
 		// Activate browser-sync on development environment
 		if ( getenv( 'APP_ENV' ) === 'development' ) :

--- a/mix-manifest.json
+++ b/mix-manifest.json
@@ -1,8 +1,0 @@
-{
-    "/assets/dist/js/app.js": "/assets/dist/js/app.js",
-    "/assets/dist/css/style.css": "/assets/dist/css/style.css",
-    "/assets/dist/css/admin.css": "/assets/dist/css/admin.css",
-    "/assets/dist/css/gutenberg.css": "/assets/dist/css/gutenberg.css",
-    "/assets/dist/js/gutenberg.js": "/assets/dist/js/gutenberg.js",
-    "/assets/dist/js/admin.js": "/assets/dist/js/admin.js"
-}

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -10,11 +10,7 @@ let mix = require( 'laravel-mix' );
 // BrowserSync and LiveReload on `npm run watch` command
 // Update the `proxy` and the location of your SSL Certificates if you're developing over HTTPS
 mix.browserSync({
-	proxy: 'https://wp.dev',
-	https: {
-		key: '/Users/alecaddd/.valet/Certificates/wp.dev.key',
-		cert: '/Users/alecaddd/.valet/Certificates/wp.dev.crt'
-	},
+	proxy: 'http://localhost',
 	files: [
 		'**/*.php',
 		'assets/dist/css/**/*.css',
@@ -30,8 +26,7 @@ mix.autoload({
 	'jquery': ['jQuery', '$']
 });
 
-// Fix for Windows Environment
-mix.setPublicPath('./');
+mix.setPublicPath('./assets/dist');
 
 // Compile assets
 mix.js( 'assets/src/scripts/app.js', 'assets/dist/js' )
@@ -40,3 +35,8 @@ mix.js( 'assets/src/scripts/app.js', 'assets/dist/js' )
 	.sass( 'assets/src/sass/style.scss', 'assets/dist/css' )
 	.sass( 'assets/src/sass/admin.scss', 'assets/dist/css' )
 	.sass( 'assets/src/sass/gutenberg.scss', 'assets/dist/css' );
+
+// Add versioning to assets in production environment
+if ( mix.inProduction() ) {
+	mix.version();
+}


### PR DESCRIPTION
Notice the mix() function in wp_enqueue_...
It provides the path to a versioned asset by Laravel Mix using querystring-based cache-busting (This means, the file name won't change, but the md5. Look [here](https://github.com/JeffreyWay/laravel-mix/issues/920) for more information)

Wasn't sure where to put the helper functions `mix()` and `starts_with()` so I threw them into  `inc/Helpers.php`. Please rearrange it to fit your inc-structure