### PR TITLE
Change Custom Class name to PostTypes

### DIFF
--- a/inc/Custom/PostTypes.php
+++ b/inc/Custom/PostTypes.php
@@ -6,7 +6,7 @@ namespace Awps\Custom;
  * Custom
  * use it to write your custom functions.
  */
-class Custom
+class PostTypes
 {
 	/**
      * register default hooks and actions for WordPress

--- a/inc/Init.php
+++ b/inc/Init.php
@@ -24,7 +24,7 @@ final class Init
 			Setup\Setup::class,
 			Setup\Menus::class,
 			Setup\Enqueue::class,
-			Custom\Custom::class,
+			Custom\PostTypes::class,
 			Custom\Admin::class,
 			Custom\Extras::class,
 			Api\Customizer::class,


### PR DESCRIPTION
I am personally confused every time I am looking at this file. 

I think this will make things more clear and consistent to the repo as we name Admin Pages as `Admin/Pages` and so will `Custom/PostTypes`