### PR TITLE
Added "wp_body_open" hook

### DIFF
--- a/header.php
+++ b/header.php
@@ -21,6 +21,7 @@
 </head>
 
 <body <?php body_class(); ?>>
+<?php wp_body_open(); ?>
 	<div id="page" class="site" <?php echo ! is_customize_preview() ?: 'style="padding: 0 40px;"'; ?>>
 
 		<header id="masthead" class="site-header" role="banner">


### PR DESCRIPTION
Since version 5.2, a new required hook was introduced, namely `wp_body_open()`.
Its function is similar to the already present `wp_head()` and `wp_footer()`.

I simply added it just after the `<body>` tag in `header.php`.

If you want to document yourself about this before merging, [here is an article](https://generatewp.com/wordpress-5-2-action-that-every-theme-should-use/) that better explain this, and [here is the official documentation](https://developer.wordpress.org/reference/functions/wp_body_open/) on the Codex.