### PR TITLE
html <Input> needs an id for <label for> to work

### DIFF
--- a/inc/Api/Callbacks/SettingsCallback.php
+++ b/inc/Api/Callbacks/SettingsCallback.php
@@ -35,6 +35,6 @@ class SettingsCallback
 	public function first_name()
 	{
 		$first_name = esc_attr( get_option( 'first_name' ) );
-		echo '<input type="text" class="regular-text" name="first_name" value="'.$first_name.'" placeholder="First Name" />';
+		echo '<input id="first_name" type="text" class="regular-text" name="first_name" value="'.$first_name.'" placeholder="First Name" />';
 	}
 }


### PR DESCRIPTION
The label for the admin options in does not select the input field (first_name) in Chrome and Edge. The <input> element does not have a "id" attribute.