### PR TITLE
update text domain in phpcs config

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -55,7 +55,7 @@
 		 Multiple valid text domains can be provided as a comma-delimited list. -->
 	<rule ref="WordPress.WP.I18n">
 		<properties>
-			<property name="text_domain" type="array" value="twentytwentyone" />
+			<property name="text_domain" type="array" value="awps" />
 		</properties>
 	</rule>
 


### PR DESCRIPTION
Updated text domain in phpcs rules.
It was set to "twentytwentyone" and gave errors when trying to lint php files