### PR TITLE
add wptrt/wpthemereview composer dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
 		"php-parallel-lint/php-parallel-lint": "^1.2",
 		"phpcompatibility/phpcompatibility-wp": "^2.1",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
-		"wp-coding-standards/wpcs": "^2.3"
+		"wp-coding-standards/wpcs": "^2.3",
+		"wptrt/wpthemereview": "^0.2.1"
 	},
 	"autoload": {
 		"psr-4": { "Awps\\": "./inc" },


### PR DESCRIPTION
Added `wptrt/wpthemereview` to composer dev dependencies.

When trying to run phpcs, it produced an error claiming that 

```
ERROR: Referenced sniff "WPThemeReview" does not exist
```

Installing this dependency solved the problem